### PR TITLE
fixed (role-tag & user-info-header color)  && add user's condition color hover

### DIFF
--- a/dist/dark.css
+++ b/dist/dark.css
@@ -685,8 +685,8 @@ code,
 .rc-table-body .rc-table-tr:hover {
   background-color: #2a2c31;
 }
-.message .info .is-bot,
-.message .info .role-tag {
+.message .title .is-bot,
+.message .title .role-tag {
   background-color: #7289da;
   color: #fff;
 }
@@ -1121,4 +1121,13 @@ code,
 }
 .reply-preview .message {
   margin-top: 0px;
+}
+.contextual-bar__header {
+  background-color: #2a2c31;
+}
+.emoji-picker {
+  background-color: #2a2c31;
+}
+.rc-popover__item:hover {
+  background-color: rgba(0, 0, 0, 0.3); /* @transparent-dark */
 }


### PR DESCRIPTION
On Rocketchat v1.2.1 environment
- fixed
  - role-tag color
![image](https://user-images.githubusercontent.com/37448236/60632959-6bcb6500-9e43-11e9-9b86-012afd74599f.png)
  - user-info-header color(mentioned https://github.com/0x0049/Rocket.Chat.Dark/issues/20#issuecomment-506314713)
![image](https://user-images.githubusercontent.com/37448236/60632972-830a5280-9e43-11e9-8506-49565dc4d99c.png)
  - emoji background color(mentioned same https://github.com/0x0049/Rocket.Chat.Dark/issues/20#issuecomment-505801387)  
![image](https://user-images.githubusercontent.com/37448236/60633390-6cfd9180-9e45-11e9-9053-133792f3a158.png)

- add
  - user's condition color hover
![image](https://user-images.githubusercontent.com/37448236/60633060-f2804200-9e43-11e9-8158-bd90203ff93c.png)
